### PR TITLE
Updated deprecated pybind constructs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,6 @@ set(CMAKE_CXX_STANDARD 14)
 # This sets interprocedural optimization off as this leads to some problems on some systems
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
-
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/definitions.h.in ${CMAKE_CURRENT_BINARY_DIR}/src/definitions.h)
 
 

--- a/src/core/monomial.cpp
+++ b/src/core/monomial.cpp
@@ -21,8 +21,14 @@ void define_monomial(py::module& m) {
         .def("__getitem__", [](const Monomial::Arg& m, std::size_t index) { return *(m->begin()+index); })
         .def("__iter__", [](const Monomial::Arg& m) { return py::make_iterator(m->begin(), m->end()); },
                             py::keep_alive<0, 1>() /* Essential: keep object alive while iterator exists */)
-        .def("__getstate__", [](const Monomial& val) -> std::tuple<std::string> { throw NoPickling(); })
-        .def("__setstate__", [](Monomial& val, const std::tuple<std::string>& data) { throw NoPickling(); })
+        .def(py::pickle(
+                [](const Monomial& val) -> std::tuple<std::string> {
+                    throw NoPickling();
+                },
+                [](const std::tuple<std::string>& data) -> std::shared_ptr<Monomial> {
+                    throw NoPickling();
+                }
+            ))
         .def("__hash__", [](const Monomial& v) { std::hash<Monomial> h; return h(v);})
     ;
 

--- a/src/core/variable.cpp
+++ b/src/core/variable.cpp
@@ -60,12 +60,14 @@ void define_variable(py::module& m) {
         .def("__str__", &streamToString<carl::Variable>)
         .def_property_readonly("is_no_variable", [](const carl::Variable& v) {return v == carl::Variable::NO_VARIABLE;})
             // TODO get state has an issue if there are several variables with the same name; they cannot be distinguished afterwards
-        .def("__getstate__", [](const carl::Variable& v) { return std::make_tuple<std::string, std::string>(v.name(), carl::to_string(v.type()));})
-
-        .def("__setstate__", [](carl::Variable& v, const std::tuple<std::string, std::string>& data ) {
-                carl::Variable tmp = getOrCreateVariable(std::get<0>(data), carl::variableTypeFromString(std::get<1>(data)));
-                new(&v) carl::Variable(tmp);
-            })
+        .def(py::pickle(
+                [](const carl::Variable& v) {
+                    return std::make_tuple<std::string, std::string>(v.name(), carl::to_string(v.type()));
+                },
+                [](const std::tuple<std::string, std::string>& data ) {
+                    return getOrCreateVariable(std::get<0>(data), carl::variableTypeFromString(std::get<1>(data)));
+                }
+            ))
         .def("__hash__", [](const carl::Variable& v) { std::hash<carl::Variable> h; return h(v);})
 
     ;

--- a/src/typed_core/factorization.cpp
+++ b/src/typed_core/factorization.cpp
@@ -7,8 +7,14 @@
 void define_factorizationcache(py::module& m) {
     py::class_<carl::Cache<FactorizationPair>, std::shared_ptr<carl::Cache<FactorizationPair>>>(m, "_FactorizationCache", "Cache storing all factorized polynomials")
         .def(py::init(), "Constructor")
-        .def("__getstate__", [](const FactorizationPair& val) -> std::tuple<std::string> { throw NoPickling(); })
-        .def("__setstate__", [](FactorizationPair& val, const std::tuple<std::string>& data) { throw NoPickling(); })
+        .def(py::pickle(
+                [](const carl::Cache<FactorizationPair>& val) -> std::tuple<std::string> {
+                    throw NoPickling();
+                },
+                [](const std::tuple<std::string>& data) -> std::shared_ptr<carl::Cache<FactorizationPair>> {
+                    throw NoPickling();
+                }
+            ))
     ;
 }
 
@@ -24,7 +30,13 @@ void define_factorization(py::module& m) {
                 return py::make_iterator(f.begin(), f.end());
             }, py::keep_alive<0, 1>() /* Essential: keep object alive while iterator exists */)
 
-        .def("__getstate__", [](const Factorization& val) -> std::tuple<std::string> { throw NoPickling(); })
-        .def("__setstate__", [](Factorization& val, const std::tuple<std::string>& data) { throw NoPickling(); })
+        .def(py::pickle(
+                [](const Factorization& val) -> std::tuple<std::string> {
+                    throw NoPickling();
+                },
+                [](const std::tuple<std::string>& data) -> Factorization {
+                    throw NoPickling();
+                }
+            ))
     ;
 }

--- a/src/typed_core/factorizedpolynomial.cpp
+++ b/src/typed_core/factorizedpolynomial.cpp
@@ -48,8 +48,14 @@ void define_factorizedpolynomial(py::module& m) {
         .def(py::self != py::self)
         .def(py::self == Rational())
         .def(py::self != Rational())
-        .def("__getstate__", [](const FactorizedPolynomial& val) -> std::tuple<std::string> { throw NoPickling(); })
-        .def("__setstate__", [](FactorizedPolynomial& val, const std::tuple<std::string>& data) { throw NoPickling(); })
+        .def(py::pickle(
+                [](const FactorizedPolynomial& val) -> std::tuple<std::string> {
+                    throw NoPickling();
+                },
+                [](const std::tuple<std::string>& data) -> FactorizedPolynomial {
+                    throw NoPickling();
+                }
+            ))
         .def("__hash__", [](const FactorizedPolynomial& v) { std::hash<FactorizedPolynomial> h; return h(v);})
     ;
 }

--- a/src/typed_core/factorizedrationalfunction.cpp
+++ b/src/typed_core/factorizedrationalfunction.cpp
@@ -37,8 +37,14 @@ void define_factorizedrationalfunction(py::module& m) {
         .def(py::self == py::self)
         .def(py::self != py::self)
         .def(py::self + Rational())
-        .def("__getstate__", [](const FactorizedRationalFunction& val) -> std::tuple<std::string> { throw NoPickling(); })
-        .def("__setstate__", [](FactorizedRationalFunction& val, const std::tuple<std::string>& data) { throw NoPickling(); })
+        .def(py::pickle(
+                [](const FactorizedRationalFunction& val) -> std::tuple<std::string> {
+                    throw NoPickling();
+                },
+                [](const std::tuple<std::string>& data) -> FactorizedRationalFunction {
+                    throw NoPickling();
+                }
+            ))
         .def("__hash__", [](const FactorizedRationalFunction& v) { std::hash<FactorizedRationalFunction> h; return h(v);})
     ;
 }

--- a/src/typed_core/integer.cpp
+++ b/src/typed_core/integer.cpp
@@ -12,13 +12,13 @@ void define_cln_integer(py::module& m) {
     py::class_<cln::cl_I>(m, "Integer", "Class wrapping cln-integers")
         .def(py::init<int>())
         .def(py::init([](std::string const& val) {
-            cln::cl_I tmp;
-            bool suc = carl::try_parse<cln::cl_I>(val, tmp);
-            if(!suc) {
-                throw std::invalid_argument("Cannot translate " + val + " into an integer.");
-            }
-            return tmp; }
-            ))
+                cln::cl_I tmp;
+                bool suc = carl::try_parse<cln::cl_I>(val, tmp);
+                if(!suc) {
+                    throw std::invalid_argument("Cannot translate " + val + " into an integer.");
+                }
+                return tmp;
+            }))
         .def(py::init(&carl::convert<mpz_class, cln::cl_I>))
 
         .def(py::self + py::self)
@@ -80,16 +80,17 @@ void define_cln_integer(py::module& m) {
 void define_gmp_integer(py::module& m) {
 #ifndef PYCARL_USE_CLN
     py::class_<mpz_class>(m, "Integer", "Class wrapping gmp-integers")
-        .def("__init__", [](mpz_class &instance, int val) -> void { new (&instance) mpz_class(val); })
-        .def("__init__", [](mpz_class &instance, std::string const& val)  -> void {
-            mpz_class tmp;
-            bool suc = carl::try_parse<mpz_class>(val, tmp);
-            if(!suc) {
-                throw std::invalid_argument("Cannot translate " + val + " into an integer.");
-            }
-            new (&instance) mpz_class(tmp); })
+        .def(py::init<int>())
+        .def(py::init([](std::string const& val) {
+                mpz_class tmp;
+                bool suc = carl::try_parse<mpz_class>(val, tmp);
+                if(!suc) {
+                    throw std::invalid_argument("Cannot translate " + val + " into an integer.");
+                }
+                return tmp;
+            }))
 #ifdef PYCARL_HAS_CLN
-        .def("__init__", [](mpz_class &instance, cln::cl_I const& val) -> void { auto tmp = carl::convert<cln::cl_I, mpz_class>(val); new (&instance) mpz_class(tmp);})
+        .def(py::init(&carl::convert<cln::cl_I, mpz_class>))
 #endif
 
         .def("__add__", [](const mpz_class& lhs, const mpz_class& rhs) -> mpz_class { return lhs + rhs; })

--- a/src/typed_core/integer.cpp
+++ b/src/typed_core/integer.cpp
@@ -68,10 +68,14 @@ void define_cln_integer(py::module& m) {
         .def("__float__", static_cast<double (*)(cln::cl_I const&)>(&carl::toDouble))
         .def("__str__", &streamToString<cln::cl_I>)
         .def("__repr__", [](const cln::cl_I& r) { return "<Integer (cln) " + streamToString<cln::cl_I>(r) + ">"; })
-        .def("__getstate__", [](const cln::cl_I& val) {
-            return std::tuple<std::string>(carl::toString(val));})
-
-        .def("__setstate__", [](cln::cl_I& val, std::tuple<std::string> data) {cln::cl_I res = carl::parse<cln::cl_I>(std::get<0>(data)); new (&val) cln::cl_I(res); })
+        .def(py::pickle(
+                [](const cln::cl_I& val) {
+                    return std::tuple<std::string>(carl::toString(val));
+                },
+                [](std::tuple<std::string> data) {
+                    return carl::parse<cln::cl_I>(std::get<0>(data));
+                }
+            ))
         .def("__hash__", [](const cln::cl_I& v) { std::hash<cln::cl_I> h; return h(v);})
     ;
 #endif
@@ -143,9 +147,14 @@ void define_gmp_integer(py::module& m) {
         .def("__float__", static_cast<double (*)(mpz_class const&)>(&carl::toDouble))
         .def("__str__", &streamToString<mpz_class>)
         .def("__repr__", [](const mpz_class& r) { return "<Integer (gmp) " + streamToString<mpz_class>(r) + ">"; })
-        .def("__getstate__", [](const mpz_class& val) {
-            return std::tuple<std::string>(carl::toString(val));})
-        .def("__setstate__", [](mpz_class& val, std::tuple<std::string> data) {mpz_class res = carl::parse<mpz_class>(std::get<0>(data)); new (&val) mpz_class(res); })
+        .def(py::pickle(
+                [](const mpz_class& val) -> std::tuple<std::string> {
+                    return std::tuple<std::string>(carl::toString(val));
+                },
+                [](const std::tuple<std::string>& data) -> mpz_class {
+                    return carl::parse<mpz_class>(std::get<0>(data));
+                }
+            ))
         .def("__hash__", [](const mpz_class& v) { std::hash<mpz_class> h; return h(v);})
     ;
 #endif

--- a/src/typed_core/interval.cpp
+++ b/src/typed_core/interval.cpp
@@ -97,8 +97,14 @@ void define_interval(py::module& m) {
 		
 		.def("__str__", &streamToString<Interval>)
 		.def("__repr__", [](const Interval& i) { return "<Interval " + streamToString<Interval>(i) + ">"; })
-        .def("__getstate__", [](const Interval& val) -> std::tuple<std::string> { throw NoPickling(); })
-        .def("__setstate__", [](Interval& val, const std::tuple<std::string>& data) { throw NoPickling(); })
+        .def(py::pickle(
+                [](const Interval& val) -> std::tuple<std::string> {
+                    throw NoPickling();
+                },
+                [](const std::tuple<std::string>& data) -> Interval {
+                    throw NoPickling();
+                }
+            ))
 	;
 	
 	m.def("isInteger", [](const Interval& i){ return carl::isInteger(i); });

--- a/src/typed_core/polynomial.cpp
+++ b/src/typed_core/polynomial.cpp
@@ -91,8 +91,14 @@ void define_polynomial(py::module& m) {
         .def("__iter__", [](const Polynomial& p) {
                 return py::make_iterator(p.begin(), p.end());
             }, py::keep_alive<0, 1>() /* Essential: keep object alive while iterator exists */)
-        .def("__getstate__", [](const Polynomial& val) -> std::tuple<std::string> { throw NoPickling(); })
-        .def("__setstate__", [](Polynomial& val, const std::tuple<std::string>& data) { throw NoPickling(); })
+        .def(py::pickle(
+                [](const Polynomial& val) -> std::tuple<std::string> {
+                    throw NoPickling();
+                },
+                [](const std::tuple<std::string>& data) -> Polynomial {
+                    throw NoPickling();
+                }
+            ))
         .def("__hash__", [](const Polynomial& v) { std::hash<Polynomial> h; return h(v);})
     ;
 }

--- a/src/typed_core/rational.cpp
+++ b/src/typed_core/rational.cpp
@@ -115,14 +115,14 @@ void define_cln_rational(py::module& m) {
                 return carl::getDenom(val);
             })
 
-        .def("__getstate__", [](const cln::cl_RA& val) {
-                return std::pair<std::string, std::string>(carl::toString(carl::getNum(val)), carl::toString(carl::getDenom(val)));
-            })
-
-        .def("__setstate__", [](cln::cl_RA& val, std::pair<std::string, std::string> data) {
-                cln::cl_RA res = carl::parse<cln::cl_RA>(data.first) / carl::parse<cln::cl_RA>(data.second);
-                new (&val) cln::cl_RA(res);
-            })
+        .def(py::pickle(
+                [](const cln::cl_RA& val) {
+                    return std::pair<std::string, std::string>(carl::toString(carl::getNum(val)), carl::toString(carl::getDenom(val)));
+                },
+                [](std::pair<std::string, std::string> data) {
+                    return carl::parse<cln::cl_RA>(data.first) / carl::parse<cln::cl_RA>(data.second);
+                }
+            ))
         .def("__hash__", [](const cln::cl_RA& v) { std::hash<cln::cl_RA> h; return h(v);})
     ;
 
@@ -236,14 +236,14 @@ void define_gmp_rational(py::module& m) {
                 return carl::getDenom(val);
             })
 
-        .def("__getstate__", [](const mpq_class& val) {
-                return std::pair<std::string, std::string>(carl::toString(carl::getNum(val)), carl::toString(carl::getDenom(val)));
-            })
-
-        .def("__setstate__", [](mpq_class& val, std::pair<std::string, std::string> data) {
-                mpq_class res = carl::parse<mpq_class>(data.first) / carl::parse<mpq_class>(data.second);
-                new (&val) mpq_class(res);
-            })
+        .def(py::pickle(
+                [](const mpq_class& val) {
+                    return std::pair<std::string, std::string>(carl::toString(carl::getNum(val)), carl::toString(carl::getDenom(val)));
+                },
+                [](std::pair<std::string, std::string> data) {
+                    return carl::parse<mpq_class>(data.first) / carl::parse<mpq_class>(data.second);
+                }
+            ))
         .def("__hash__", [](const mpq_class& v) { std::hash<mpq_class> h; return h(v);})
     ;
 

--- a/src/typed_core/rationalfunction.cpp
+++ b/src/typed_core/rationalfunction.cpp
@@ -72,8 +72,14 @@ void define_rationalfunction(py::module& m) {
         .def("__eq__", [](const RationalFunction& lhs, const Polynomial& rhs) -> bool {return lhs == RationalFunction(rhs);})
         .def("__ne__", [](const RationalFunction& lhs, const Polynomial& rhs) -> bool {return lhs != RationalFunction(rhs);})
 
-        .def("__getstate__", [](const RationalFunction&) -> std::tuple<std::string> { throw NoPickling(); })
-        .def("__setstate__", [](RationalFunction&, const  std::tuple<std::string>&) { throw NoPickling(); })
+        .def(py::pickle(
+                [](const RationalFunction& val) -> std::tuple<std::string> {
+                    throw NoPickling();
+                },
+                [](const std::tuple<std::string>& data) -> RationalFunction {
+                    throw NoPickling();
+                }
+            ))
         .def("__hash__", [](const RationalFunction& v) { std::hash<RationalFunction> h; return h(v);})
     ;
 }

--- a/src/typed_core/term.cpp
+++ b/src/typed_core/term.cpp
@@ -51,8 +51,14 @@ void define_term(py::module& m) {
 
         .def("__str__", &streamToString<Term>)
 
-        .def("__getstate__", [](const Term& val) -> std::tuple<std::string> { throw NoPickling(); })
-        .def("__setstate__", [](Term& val, const std::tuple<std::string>& data) { throw NoPickling(); })
+        .def(py::pickle(
+                [](const Term& val) -> std::tuple<std::string> {
+                    throw NoPickling();
+                },
+                [](const std::tuple<std::string>& data) -> Term {
+                    throw NoPickling();
+                }
+            ))
         .def("__hash__", [](const Term& v) { std::hash<Term> h; return h(v);})
     ;
 }

--- a/src/typed_formula/constraint.cpp
+++ b/src/typed_formula/constraint.cpp
@@ -47,8 +47,14 @@ void define_constraint(py::module& m) {
 
         .def_property_readonly("relation", &Constraint::relation)
         .def_property_readonly("lhs", &Constraint::lhs)
-        .def("__getstate__", [](const Constraint& val) -> std::tuple<std::string> { throw NoPickling(); })
-        .def("__setstate__", [](Constraint& val, const std::tuple<std::string>& data) { throw NoPickling(); })
+        .def(py::pickle(
+                [](const Constraint& val) -> std::tuple<std::string> {
+                    throw NoPickling();
+                },
+                [](const std::tuple<std::string>& data) -> Constraint {
+                    throw NoPickling();
+                }
+            ))
     ;
 }
 //
@@ -60,8 +66,14 @@ void define_simple_constraint(py::module& m) {
 
         .def("lhs", &SimpleConstraint::lhs, "Get the left hand side of the constraint")
         .def("rel", &SimpleConstraint::rel, "Get the relation of the constraint")
-        .def("__getstate__", [](const SimpleConstraint& val) -> std::tuple<std::string> { throw NoPickling(); })
-        .def("__setstate__", [](SimpleConstraint& val, const std::tuple<std::string>& data) { throw NoPickling(); })
+        .def(py::pickle(
+                [](const SimpleConstraint& val) -> std::tuple<std::string> {
+                    throw NoPickling();
+                },
+                [](const std::tuple<std::string>& data) -> SimpleConstraint {
+                    throw NoPickling();
+                }
+            ))
     ;
     
     py::class_<SimpleConstraintRatFunc>(m, "SimpleConstraintRatFunc")
@@ -72,7 +84,13 @@ void define_simple_constraint(py::module& m) {
         .def("lhs", &SimpleConstraintRatFunc::lhs, "Get the left hand side of the constraint")
         .def("rel", &SimpleConstraintRatFunc::rel, "Get the relation of the constraint")
 
-        .def("__getstate__", [](const SimpleConstraintRatFunc& val) -> std::tuple<std::string> { throw NoPickling(); })
-        .def("__setstate__", [](SimpleConstraintRatFunc& val, const std::tuple<std::string>& data) { throw NoPickling(); })
+        .def(py::pickle(
+                [](const SimpleConstraintRatFunc& val) -> std::tuple<std::string> {
+                    throw NoPickling();
+                },
+                [](const std::tuple<std::string>& data) -> SimpleConstraintRatFunc {
+                    throw NoPickling();
+                }
+            ))
     ;
 }

--- a/src/typed_formula/formula.cpp
+++ b/src/typed_formula/formula.cpp
@@ -64,7 +64,13 @@ void define_formula(py::module& m) {
         .def("get_subformulas", &Formula::subformulas, "Get list of subformulas for n-ary formula")
         .def("get_constraint", &Formula::constraint, "Get constraint of constraint formula")
 
-        .def("__getstate__", [](const Formula& val) -> std::tuple<std::string> { throw NoPickling(); })
-        .def("__setstate__", [](Formula& val, const std::tuple<std::string>& data) { throw NoPickling(); })
+        .def(py::pickle(
+                [](const Formula& val) -> std::tuple<std::string> {
+                    throw NoPickling();
+                },
+                [](const std::tuple<std::string>& data) -> Formula {
+                    throw NoPickling();
+                }
+            ))
     ;
 }


### PR DESCRIPTION
- replaced `__init__` by `py::init`
- replaced `__getstate__`/`__setstate__` by `py::pickle`