### PR TITLE
Disable interprocedural optimization to fix issues with singletons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ add_subdirectory(resources/pybind11)
 
 set(PYCARL_HAS_CLN ${CARL_USE_CLN_NUMBERS})
 set(CMAKE_CXX_STANDARD 14)
+
+# This sets interprocedural optimization off as this leads to some problems on some systems
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/definitions.h.in ${CMAKE_CURRENT_BINARY_DIR}/src/definitions.h)

--- a/tests/core/test_term.py
+++ b/tests/core/test_term.py
@@ -39,3 +39,9 @@ class TestTerm(PackageSelector):
         term3 = term1 * term2
         termOrig = package.Term(6, var * var * var)
         assert term3 == termOrig
+
+    def test_singleton_bug(self, package):
+        var = pycarl.Variable("x")
+        assert str(package.Term(var)) == "x"
+        # Ensures bug is fixed where second call would yield '1' instead of 'x'
+        assert str(package.Term(var)) == "x"


### PR DESCRIPTION
Fixes issues with singletons in Carl which lead to various problems including segfaults.