### PR TITLE
Added py::prepend to fix overlead order of __str__ for enums

### DIFF
--- a/src/formula/relation.cpp
+++ b/src/formula/relation.cpp
@@ -1,7 +1,7 @@
 #include "relation.h"
 #include "src/helpers.h"
 
-#include <carl/formula/Formula.h>
+#include <carl/core/Relation.h>
 
 void define_relation(py::module& m) {
     py::enum_<carl::Relation>(m, "Relation")
@@ -11,6 +11,6 @@ void define_relation(py::module& m) {
         .value("LEQ", carl::Relation::LEQ)
         .value("GREATER", carl::Relation::GREATER)
         .value("GEQ", carl::Relation::GEQ)
-        .def("__str__", &streamToString<carl::Relation>)
+        .def("__str__", &streamToString<carl::Relation>, py::prepend() /* use custom method instead of default enum overload */)
     ;
 }

--- a/tests/formula/test_relation.py
+++ b/tests/formula/test_relation.py
@@ -1,0 +1,9 @@
+import pycarl
+from pycarl.formula import Relation
+
+
+class TestRelation():
+    def test_to_string(self):
+        r = Relation.LESS
+        assert str(r) == "<"
+        assert str(Relation.GEQ) == ">="


### PR DESCRIPTION
Pybind11 overloads are tried in the order they were registered with pybind11. As a result, enums used the default `__str__` method instead of the custom one. Adding `py::prepend()` fixes this issue.
See https://github.com/pybind/pybind11/issues/2537 and the [pybind11 documentation](https://pybind11.readthedocs.io/en/stable/advanced/functions.html#overload-resolution-order) for more info.

Also added a dedicated test case because the issue was only triggered in Prophesy.