### PR TITLE
Automatic formatting via black + CI support

### DIFF
--- a/.github/workflows/formatapply.yml
+++ b/.github/workflows/formatapply.yml
@@ -1,0 +1,38 @@
+name: apply-code-format
+
+on: [ workflow_dispatch ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable
+        with:
+          options: ""
+          src: "."
+          jupyter: true
+      - name: Commit Formatting
+        run: |
+          git config user.name 'Auto Format'
+          git config user.email 'dev@stormchecker.org'
+          if [ -z "$(git status --porcelain)" ]
+          then
+          echo "Code did not change"
+          else
+          git commit -am "Applied code formatting"
+          git rev-parse HEAD >> .git-blame-ignore-revs
+          git commit -am "Add code formatting commit to .git-blame-ignore-revs"
+          fi
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          branch: ci/apply-code-format
+          delete-branch: true
+          title: 'Code formatting'
+          body: |
+            Auto-generated pull request triggered by the `apply-code-format` workflow.
+            - Manually close and reopen this PR to trigger the CI.
+            - Make sure to **merge** (and not rebase) this PR so that the added commit hash in `.git-blame-ignore-revs` remains valid.

--- a/.github/workflows/formatcheck.yml
+++ b/.github/workflows/formatcheck.yml
@@ -1,0 +1,15 @@
+name: check-code-format
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: psf/black@stable
+      with:
+        options: "--check --diff --color"
+        src: "."
+        jupyter: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.black]
+line-length = 160
+target-version = [
+    "py37",
+    "py38",
+    "py39",
+    "py310",
+    "py311",
+]
+include = "\\.pyi?$"

--- a/setup.py
+++ b/setup.py
@@ -219,7 +219,8 @@ setup(
                     'packaging'],
     tests_require=['pytest'],
     extras_require={
-        "doc": ["Sphinx", "sphinx-bootstrap-theme"]
+        "doc": ["Sphinx", "sphinx-bootstrap-theme"],
+        "dev": ["black"],
     },
     python_requires='>=3.7',  # required by packaging
 )


### PR DESCRIPTION
- Use [black](https://black.readthedocs.io) for automatic Python code formatting. After installing the `black` package, code can be formatted using `black .`
- CI support for checking and applying code formatting, similar to the Storm workflows.

Results of the CI can be seen in [this action](https://github.com/volkm/pycarl/actions/runs/5740662547) and [this PR](https://github.com/volkm/pycarl/pull/1).