### PR TITLE
Pycarl version 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Changelog
 Version 2.2.x
 -------------
 
+### Version 2.2.1 (2024/08)
+Requires carl-storm version >= 14.23
+
+- Added support for intervals with different number types
+- Automated code formatting
+- Developer: improved build and CMake support
+- Developer: improved CI
+
 ### Version 2.2.0 (2023/06)
 Requires carl-storm version >= 14.23
 


### PR DESCRIPTION
New version of pycarl

I checked and it is still compatible with carl-storm version 14.23.