### PR TITLE
Removed support for test command in setup.py

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -13,10 +13,8 @@ on:
   pull_request:
 
 env:
-  GIT_URL: "${{ github.server_url }}/${{ github.repository }}.git"
-  BRANCH: "${{ github.ref }}"
-  # GitHub runners currently have two cores
-  NR_JOBS: "2"
+  # GitHub runners currently have 4 cores
+  NR_JOBS: "4"
 
 jobs:
   indepthTests:
@@ -53,7 +51,7 @@ jobs:
       - name: Run Docker
         run: docker run -d -it --name ci movesrwth/pycarl:ci-${{ matrix.debugOrRelease }}
       - name: Run tests
-        run: docker exec ci bash -c "cd /opt/pycarl; python setup.py test"
+        run: docker exec ci bash -c "cd /opt/pycarl; pip install pytest; pytest"
 
 
   distroTests:
@@ -80,7 +78,7 @@ jobs:
       - name: Run Docker
         run: docker run -d -it --name ci movesrwth/pycarl:ci-${{ matrix.debugOrRelease }}
       - name: Run tests
-        run: docker exec ci bash -c "cd /opt/pycarl; python setup.py test"
+        run: docker exec ci bash -c "cd /opt/pycarl; pip install pytest; pytest"
 
   deploy:
     name: Build, Test and deploy documentation
@@ -105,7 +103,7 @@ jobs:
       - name: Run Docker
         run: docker run -d -it --name ci movesrwth/pycarl:ci-${{ matrix.debugOrRelease }}
       - name: Run tests
-        run: docker exec ci bash -c "cd /opt/pycarl; python setup.py test"
+        run: docker exec ci bash -c "cd /opt/pycarl; pip install pytest; pytest"
 
         # Build and publish documentation for release build
       - name: Install documentation dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,21 @@ target-version = [
     "py310",
     "py311",
 ]
-include = "\\.pyi?$"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--doctest-glob='*.rst'"
+testpaths = [
+    "tests",
+    "examples",
+    "doc",
+]
+python_files = [
+    "test*.py",
+    "examples/*.py",
+]
+python_functions = [
+    "*_test",
+    "test_*",
+    "example_*",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,0 @@
-[aliases]
-test=pytest
-
-[tool:pytest]
-addopts = --doctest-glob='*.rst'
-testpaths = tests/ examples/ doc/
-python_files = test*.py examples/*.py
-python_functions = *_test test_* example_*

--- a/setup.py
+++ b/setup.py
@@ -218,11 +218,10 @@ setup(
     ],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
-    setup_requires=["pytest-runner", "packaging"],
-    tests_require=["pytest"],
+    setup_requires=["packaging"],
     extras_require={
         "doc": ["Sphinx", "sphinx-bootstrap-theme"],
-        "dev": ["black"],
+        "dev": ["tox"],
     },
     python_requires=">=3.7",  # required by packaging
 )


### PR DESCRIPTION
The `test` command is not supported anymore in setuptools. This fix manually triggers the tests via `pytest`.

The next step would be to completely renew the build process and incorporate tox.