### PR TITLE
Inform about move from pycarl into stormpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> [!WARNING]
+> ## Pycarl is now part of [stormpy](https://moves-rwth.github.io/stormpy/) and this repository is no longer maintained. Please use the [Github repository of stormpy](https://github.com/moves-rwth/stormpy) instead.
+
+
 Pycarl - Python Bindings for CArL
 =================================
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -90,6 +90,10 @@ html_theme = "bootstrap"
 
 html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
 
+rst_prolog = """.. warning::
+    Pycarl is now part of `stormpy <https://moves-rwth.github.io/stormpy>`_ and this repository is no longer maintained. Please use the `Github repository of stormpy <https://github.com/moves-rwth/stormpy>`_ instead.
+"""
+
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -17,6 +17,9 @@ Before installing pycarl, make sure
 Installation Steps
 ====================
 
+.. warning::
+    Pycarl is now part of `stormpy <https://moves-rwth.github.io/stormpy>`_ and this repository is no longer maintained. Please use the `Github repository of stormpy <https://github.com/moves-rwth/stormpy>`_ instead.
+
 Virtual Environments
 --------------------
 


### PR DESCRIPTION
Add warning to inform users that pycarl is now part of stormpy.

After merging the PR, I suggest to archive this repository and make it read-only.